### PR TITLE
Dj/keep db open

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: crystal
+language: generic
 
 services:
   - docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     depends_on:
       - pg
       - mysql
-    volumes:
-      - '.:/app/user'
   pg:
     image: postgres:9.5
   mysql:

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -5,11 +5,11 @@ require "db"
 # objects to perform actions against a specific database.  Each adapter needs
 # to implement these methods.
 abstract class Granite::Adapter::Base
-  property url : String
+  property database : DB::Database
 
   def initialize(adapter : String)
     if url = ENV["DATABASE_URL"]? || env(settings(adapter)["database"].to_s)
-      @url = url
+      @database = DB.open(url)
     else
       raise "database url needs to be set in the config/database.yml or DATABASE_URL environment variable"
     end
@@ -27,12 +27,7 @@ abstract class Granite::Adapter::Base
   end
  
   def open(&block)
-    db = DB.open(@url)
-    begin
-      yield db
-    ensure
-      db.close
-    end
+    yield @database
   end
 
   # remove all rows from a table and reset the counter on the id.


### PR DESCRIPTION
This change avoids opening and closing the db connection for every request.  This had a significant performance increase in the TechEmpower benchmarks.

We will probably want to add error handling if the connection fails but I will leave that for a later change.