### PR TITLE
Ecr database.yml

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-export PG_DATABASE_URL=postgres://drujensen@localhost:5432/kemalyst
-export MYSQL_DATABASE_URL=mysql://drujensen@localhost:3306/kemalyst
-export SQLITE_DATABASE_URL=sqlite3:./config/kemalyst.db
+export PG_DATABASE_URL=postgres://granite:password@localhost:5432/granite_db
+export MYSQL_DATABASE_URL=mysql://granite:password@localhost:3306/granite_db
+export SQLITE_DATABASE_URL=sqlite3:./config/granite.db

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ dependencies:
 ```
 
 Next you will need to create a `config/database.yml`
-You can leverage environment variables using ${} syntax.
+You can leverage environment variables using ${} syntax or ECR.
 
 ```yaml
 mysql:
   database: "mysql://user:pass@mysql:3306/test"
 pg:
-  database: "postgres://postgres:@pg:5432/postgres"
+  database: "<%= ENV["PG_DATABASE_URL"] %>"
 sqlite:
   database: "sqlite3:./config/test.db"
 ```

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ posts = Post.all("JOIN comments c ON c.post_id = post.id
 
 ### Callbacks
 
-There is support for callbacks on certain events.  
+There is support for callbacks on certain events.
 
 Here is an example:
 ```crystal
@@ -259,6 +259,33 @@ You can register callbacks for the following events:
 3. Commit your changes (git commit -am 'Add some feature')
 4. Push to the branch (git push origin my-new-feature)
 5. Create a new Pull Request
+
+## Running tests
+
+
+1. Install dependencies with `$ crystal deps`
+2. Update .env to use appropriate ENV variables, or create appropriate databases.
+
+### PostgreSQL
+```sql
+CREATE USER granite WITH PASSWORD 'password';
+
+CREATE DATABASE granite_db;
+
+GRANT ALL PRIVILEGES ON DATABASE granite_db TO granite;
+```
+### MySQL
+```sql
+CREATE USER 'granite'@'localhost' IDENTIFIED BY 'password';
+
+CREATE DATABASE granite_db;
+
+GRANT ALL PRIVILEGES ON granite_db.* TO 'granite'@'localhost' WITH GRANT OPTION;
+```
+
+3. Export `.env` with `$ export .env`
+4. `$ crystal spec`
+
 
 ## Contributors
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@ mysql:
   database: "${MYSQL_DATABASE_URL}"
 
 pg:
-  database: "${PG_DATABASE_URL}"
+  database: "<%= ENV["PG_DATABASE_URL"] %>"
 
 sqlite:
   database: "${SQLITE_DATABASE_URL}"

--- a/spec/adapter/mysql_spec.cr
+++ b/spec/adapter/mysql_spec.cr
@@ -28,8 +28,8 @@ Post.exec("CREATE TABLE posts (
   body TEXT,
   total INTEGER,
   slug VARCHAR(255),
-  created_at TIMESTAMP,
-  updated_at TIMESTAMP,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (id)
 );
 ")
@@ -230,5 +230,4 @@ describe Granite::Adapter::Mysql do
       end
     end
   end
-
 end


### PR DESCRIPTION
`${}` syntax is unique to this project. Something more ubiquitous
should be used like ECR.

+ Evaluate database.yml as ECR before parsing as YAML
+ Switches the pg database config to use ECR
+ Add notes to README about using ECR, +example