### PR TITLE
One to many relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The where clause will give you full control over your query.
 When using the `all` method, the SQL selected fields will always match the
 fields specified in the model.
 
-Always pass in parameters to avoid SQL Injection.  Use a `?` (or `$1`, `$2`,.. for pg)
+Always pass in parameters to avoid SQL Injection.  Use a `?`
 in your query as placeholder. Checkout the [Crystal DB Driver](https://github.com/crystal-lang/crystal-db)
 for documentation of the drivers.
 

--- a/spec/adapter/mysql_spec.cr
+++ b/spec/adapter/mysql_spec.cr
@@ -1,8 +1,18 @@
 require "./spec_helper"
 require "../src/adapter/mysql"
 
+class Owner < Granite::ORM
+  adapter mysql
+
+  field name : String
+  timestamps
+end
+
 class Post < Granite::ORM
   adapter mysql
+
+  belongs_to :owner
+
   field name : String
   field body : String
   field total : Int32
@@ -21,12 +31,23 @@ class Chat::Room < Granite::ORM
   field name : String
 end
 
+Owner.exec("DROP TABLE IF EXISTS owners;")
+Owner.exec("CREATE TABLE owners (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  name VARCHAR(255),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY(id)
+);
+")
+
 Post.exec("DROP TABLE IF EXISTS posts;")
 Post.exec("CREATE TABLE posts (
   id BIGINT NOT NULL AUTO_INCREMENT,
   name VARCHAR(255),
   body TEXT,
   total INTEGER,
+  owner_id INTEGER,
   slug VARCHAR(255),
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -52,6 +73,7 @@ Chat::Room.exec("CREATE TABLE chat_rooms (
 
 describe Granite::Adapter::Mysql do
   Spec.before_each do
+    Owner.clear
     Post.clear
   end
 
@@ -108,6 +130,21 @@ describe Granite::Adapter::Mysql do
       slug = post.slug
       post = Post.find_by(:slug, slug)
       post.should_not be_nil
+    end
+  end
+
+  describe "#belongs_to" do
+    it "provides a method to retrieve parent" do
+      owner = Owner.new
+      owner.name = "Test Owner"
+      owner.save
+
+      post = Post.new
+      post.name = "Test Post"
+      post.owner_id = owner.id
+      post.save
+
+      post.owner.name.should eq "Test Owner"
     end
   end
 

--- a/spec/adapter/mysql_spec.cr
+++ b/spec/adapter/mysql_spec.cr
@@ -4,6 +4,8 @@ require "../src/adapter/mysql"
 class Owner < Granite::ORM
   adapter mysql
 
+  has_many :posts
+
   field name : String
   timestamps
 end
@@ -47,7 +49,7 @@ Post.exec("CREATE TABLE posts (
   name VARCHAR(255),
   body TEXT,
   total INTEGER,
-  owner_id INTEGER,
+  owner_id BIGINT,
   slug VARCHAR(255),
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -145,6 +147,28 @@ describe Granite::Adapter::Mysql do
       post.save
 
       post.owner.name.should eq "Test Owner"
+    end
+  end
+
+  describe "#has_many" do
+    it "provides a method to retrieve children" do
+      owner = Owner.new
+      owner.name = "Test Owner"
+      owner.save
+
+      post = Post.new
+      post.name = "Test Post 1"
+      post.owner_id = owner.id
+      post.save
+      post = Post.new
+      post.name = "Test Post 2"
+      post.owner_id = owner.id
+      post.save
+      post = Post.new
+      post.name = "Test Post 3"
+      post.save
+
+      owner.posts.size.should eq 2
     end
   end
 

--- a/spec/adapter/mysql_spec.cr
+++ b/spec/adapter/mysql_spec.cr
@@ -148,6 +148,19 @@ describe Granite::Adapter::Mysql do
 
       post.owner.name.should eq "Test Owner"
     end
+
+    it "provides a method to set parent" do
+      owner = Owner.new
+      owner.name = "Test Owner"
+      owner.save
+
+      post = Post.new
+      post.name = "Test Post"
+      post.owner = owner
+      post.save
+
+      post.owner_id.should eq owner.id
+    end
   end
 
   describe "#has_many" do

--- a/spec/adapter/pg_spec.cr
+++ b/spec/adapter/pg_spec.cr
@@ -50,6 +50,78 @@ describe Granite::Adapter::Pg do
       users = User.all
       users.size.should eq 2
     end
+
+    it "finds users matching clause using named substitution" do
+      user = User.new
+      user.name = "Bob"
+      user.total = 1000
+      user.save
+      user = User.new
+      user.name = "Joe"
+      user.total = 2000
+      user.save
+      user = User.new
+      user.name = "Joline"
+      user.total = 3000
+      user.save
+
+      users = User.all("WHERE name LIKE $1", ["Jo%"])
+      users.size.should eq 2
+    end
+
+    it "finds users matching clause using multiple named substitutions" do
+      user = User.new
+      user.name = "Bob"
+      user.total = 1000
+      user.save
+      user = User.new
+      user.name = "Joe"
+      user.total = 2000
+      user.save
+      user = User.new
+      user.name = "Joline"
+      user.total = 3000
+      user.save
+
+      users = User.all("WHERE name LIKE ANY(ARRAY[$1, $2])", ["Joe%", "Joline%"])
+      users.size.should eq 2
+    end
+
+    it "finds users matching clause using question mark substitution" do
+      user = User.new
+      user.name = "Bob"
+      user.total = 1000
+      user.save
+      user = User.new
+      user.name = "Joe"
+      user.total = 2000
+      user.save
+      user = User.new
+      user.name = "Joline"
+      user.total = 3000
+      user.save
+
+      users = User.all("WHERE name LIKE ?", ["Jo%"])
+      users.size.should eq 2
+    end
+
+    it "finds users matching clause using multiple question mark substitutions" do
+      user = User.new
+      user.name = "Bob"
+      user.total = 1000
+      user.save
+      user = User.new
+      user.name = "Joe"
+      user.total = 2000
+      user.save
+      user = User.new
+      user.name = "Joline"
+      user.total = 3000
+      user.save
+
+      users = User.all("WHERE name LIKE ANY(ARRAY[?, ?])", ["Joe%", "Joline%"])
+      users.size.should eq 2
+    end
   end
 
   describe "#find" do

--- a/spec/adapter/pg_spec.cr
+++ b/spec/adapter/pg_spec.cr
@@ -192,6 +192,20 @@ describe Granite::Adapter::Pg do
 
       user.parent.name.should eq "Parent 1"
     end
+
+    it "provides a method to set parent" do
+      parent = Parent.new
+      parent.name = "Parent 1"
+      parent.save
+
+      user = User.new
+      user.name = "Test User"
+      user.pass = "password"
+      user.parent = parent
+      user.save
+
+      user.parent_id.should eq parent.id
+    end
   end
 
   describe "#has_many" do

--- a/spec/adapter/pg_spec.cr
+++ b/spec/adapter/pg_spec.cr
@@ -4,6 +4,8 @@ require "../src/adapter/pg"
 class Parent < Granite::ORM
   adapter pg
 
+  has_many :users
+
   field name : String
   timestamps
 end
@@ -40,7 +42,7 @@ User.exec("CREATE TABLE users (
   name VARCHAR,
   pass VARCHAR,
   total INT,
-  parent_id INT,
+  parent_id BIGINT,
   created_at TIMESTAMP,
   updated_at TIMESTAMP
 );
@@ -189,6 +191,29 @@ describe Granite::Adapter::Pg do
       user.save
 
       user.parent.name.should eq "Parent 1"
+    end
+  end
+
+  describe "#has_many" do
+    it "provides a method to retrieve children" do
+      parent = Parent.new
+      parent.name = "Parent 1"
+      parent.save
+
+      user = User.new
+      user.name = "Test User 1"
+      user.pass = "password"
+      user.parent_id = parent.id
+      user.save
+      user = User.new
+      user.name = "Test User 2"
+      user.parent_id = parent.id
+      user.save
+      user = User.new
+      user.name = "Test User 3"
+      user.save
+
+      parent.users.size.should eq 2
     end
   end
 

--- a/spec/adapter/sqlite_spec.cr
+++ b/spec/adapter/sqlite_spec.cr
@@ -112,6 +112,19 @@ describe Granite::Adapter::Sqlite do
 
       comment.comment_thread.name.should eq "Test Thread"
     end
+
+    it "provides a method to set parent" do
+      comment_thread = CommentThread.new
+      comment_thread.name = "Test Thread"
+      comment_thread.save
+
+      comment = Comment.new
+      comment.name = "Test Comment"
+      comment.comment_thread = comment_thread
+      comment.save
+
+      comment.comment_thread_id.should eq comment_thread.id
+    end
   end
 
   describe "#has_many" do

--- a/spec/adapter/sqlite_spec.cr
+++ b/spec/adapter/sqlite_spec.cr
@@ -1,9 +1,18 @@
 require "./spec_helper"
 require "../src/adapter/sqlite"
 
+class CommentThread < Granite::ORM
+  adapter sqlite
+  table_name comment_threads
+  field name : String
+end
+
 class Comment < Granite::ORM
   adapter sqlite
   table_name comments
+
+  belongs_to :comment_thread
+
   field name : String
   field body : String
 end
@@ -15,11 +24,19 @@ class Reaction < Granite::ORM
   field emote : String
 end
 
+CommentThread.exec("DROP TABLE IF EXISTS comment_threads;")
+CommentThread.exec("CREATE TABLE comment_threads (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name VARCHAR
+);
+")
+
 Comment.exec("DROP TABLE IF EXISTS comments;")
 Comment.exec("CREATE TABLE comments (
   id INTEGER NOT NULL PRIMARY KEY,
   name VARCHAR,
-  body VARCHAR
+  body VARCHAR,
+  comment_thread_id INTEGER
 );
 ")
 
@@ -32,6 +49,7 @@ Reaction.exec("CREATE TABLE reactions (
 
 describe Granite::Adapter::Sqlite do
   Spec.before_each do
+    CommentThread.clear
     Comment.clear
   end
 
@@ -75,6 +93,21 @@ describe Granite::Adapter::Sqlite do
       name = comment.name
       comment = Comment.find_by(:name, name)
       comment.should_not be_nil
+    end
+  end
+
+  describe "#belongs_to" do
+    it "provides a method to retrieve parent" do
+      comment_thread = CommentThread.new
+      comment_thread.name = "Test Thread"
+      comment_thread.save
+
+      comment = Comment.new
+      comment.name = "Test Comment"
+      comment.comment_thread_id = comment_thread.id
+      comment.save
+
+      comment.comment_thread.name.should eq "Test Thread"
     end
   end
 

--- a/spec/adapter/sqlite_spec.cr
+++ b/spec/adapter/sqlite_spec.cr
@@ -4,6 +4,9 @@ require "../src/adapter/sqlite"
 class CommentThread < Granite::ORM
   adapter sqlite
   table_name comment_threads
+
+  has_many :comments
+
   field name : String
 end
 
@@ -108,6 +111,28 @@ describe Granite::Adapter::Sqlite do
       comment.save
 
       comment.comment_thread.name.should eq "Test Thread"
+    end
+  end
+
+  describe "#has_many" do
+    it "provides a method to retrieve children" do
+      comment_thread = CommentThread.new
+      comment_thread.name = "Test Thread"
+      comment_thread.save
+
+      comment = Comment.new
+      comment.name = "Test Comment 1"
+      comment.comment_thread_id = comment_thread.id
+      comment.save
+      comment = Comment.new
+      comment.name = "Test Comment 2"
+      comment.comment_thread_id = comment_thread.id
+      comment.save
+      comment = Comment.new
+      comment.name = "Test Comment 3"
+      comment.save
+
+      comment_thread.comments.size.should eq 2
     end
   end
 

--- a/src/granite_orm.cr
+++ b/src/granite_orm.cr
@@ -53,9 +53,11 @@ class Granite::ORM
     field {{model_name.id}}_id : Int64
 
     def {{model_name.id}}
-      parent = {{model_name.id.camelcase}}.find {{model_name.id}}_id
-      return {{model_name.id.camelcase}}.new unless parent
-      parent
+      if parent = {{model_name.id.camelcase}}.find {{model_name.id}}_id
+        parent
+      else
+        {{model_name.id.camelcase}}.new
+      end
     end
   end
 

--- a/src/granite_orm.cr
+++ b/src/granite_orm.cr
@@ -48,6 +48,17 @@ class Granite::ORM
     {% SETTINGS[:timestamps] = true %}
   end
 
+  # retrive the parent relationship
+  macro belongs_to(model_name)
+    {% FIELDS["#{model_name.id}_id".id.symbolize] = Int64 %}
+
+    def {{model_name.id}}
+      parent = {{model_name.id.camelcase}}.find {{model_name.id}}_id
+      return {{model_name.id.camelcase}}.new unless parent
+      parent
+    end
+  end
+
   {% for name in %i(before_save after_save before_create after_create before_update after_update before_destroy after_destroy) %}
     macro {{name.id}}(callback)
       \{% CALLBACKS[{{name}}] = callback.id \%}

--- a/src/granite_orm.cr
+++ b/src/granite_orm.cr
@@ -50,12 +50,26 @@ class Granite::ORM
 
   # retrive the parent relationship
   macro belongs_to(model_name)
-    {% FIELDS["#{model_name.id}_id".id.symbolize] = Int64 %}
+    field {{model_name.id}}_id : Int64
 
     def {{model_name.id}}
       parent = {{model_name.id.camelcase}}.find {{model_name.id}}_id
       return {{model_name.id.camelcase}}.new unless parent
       parent
+    end
+  end
+
+  #retrieve the children
+  macro has_many(children_table)
+    def {{children_table.id}}
+      {% children_class = children_table.id[0...-1].camelcase %}
+      {% name_space = @type.name.gsub(/::/, "_").downcase.id %}
+      {% table_name = SETTINGS[:table_name] || name_space + "s" %}
+      foreign_key = "{{children_table.id}}.{{table_name[0...-1]}}_id"
+      query = "JOIN {{table_name}} on {{table_name}}.id = #{foreign_key} WHERE {{table_name}}.id = ?"
+
+      return [] of {{children_class}} unless id
+      {{children_class}}.all(query, id)
     end
   end
 

--- a/src/granite_orm.cr
+++ b/src/granite_orm.cr
@@ -48,10 +48,11 @@ class Granite::ORM
     {% SETTINGS[:timestamps] = true %}
   end
 
-  # retrive the parent relationship
+  # define getter and setter for parent relationship
   macro belongs_to(model_name)
     field {{model_name.id}}_id : Int64
 
+    # retrieve the parent relationship
     def {{model_name.id}}
       if parent = {{model_name.id.camelcase}}.find {{model_name.id}}_id
         parent
@@ -59,9 +60,14 @@ class Granite::ORM
         {{model_name.id.camelcase}}.new
       end
     end
+
+    # set the parent relationship
+    def {{model_name.id}}=(parent)
+      @{{model_name.id}}_id = parent.id
+    end
   end
 
-  #retrieve the children
+  # define getter for related children
   macro has_many(children_table)
     def {{children_table.id}}
       {% children_class = children_table.id[0...-1].camelcase %}


### PR DESCRIPTION
The goal of this PR is to add the `belongs_to` and `has_many` macros to Granite ORM Models to allow easier access to related data.

This addresses #30 

To Do:
- [x] `belongs_to`
- [x] `belongs_to` adapter tests
- [x] `belongs_to` setter
- [x] `has_many`
- [x] `has_many` adapter tests